### PR TITLE
Change selected color

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -51,8 +51,8 @@ body {
 }
 
 .selected {
-	background: rgba(0, 127, 255, 0.9) !important;
-	border-color: rgba(0, 127, 255, 0.9) !important;
+	background: rgba(0, 255, 127, 0.9) !important;
+	border-color: rgba(0, 255, 127, 0.9) !important;
 	color: #fff !important;
 }
 


### PR DESCRIPTION
The background colors of the selected item (`rgba(0, 127, 255, 0.9)`) and of items with hover/active state (`#39f;` AKA `rgb(51, 153, 255)` are very similar shades of blue.  Change the background color of the selected item to green.

Partially addresses issue: RJHsiao/ListOpenedTabs#6